### PR TITLE
Working multiple inputs

### DIFF
--- a/drivers/.gitignore
+++ b/drivers/.gitignore
@@ -6,10 +6,8 @@
 *.mod.c
 Module.symvers
 modules.order
-
-# generated file by drivergen.py
-driver.c
-dma_bufferset.h
+.cache.mk
+*.o.d
 
 # generated file during building module
 .tmp_versions/

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,40 +1,29 @@
-ARCH := arm64
-KER_DIR := /home/steven/work/linux-xlnx/
-
-HWCONFIG := ../hwconfig.yml
+KER_DIR := /lib/modules/`uname -r`/build
 
 # There are three modules created from this source code
 #   cmabuffer - Provides access to large contiguous memory buffers from Linux CMA
 #   hwacc - Driver for hardware accelerator, using one or more DMA engines
-#   xilcam - Driver for VDMA engine connected to the Xilinx camera
-obj-m := hwacc.o xilcam.o cmabuffer.o
+obj-m := hwacc.o cmabuffer.o
+ccflags-y := -Wall
 
 # Dependencies for each of the modules
 # Note that some code related to buffer handling and ioctl numbers is shared
 hwacc-objs := driver.o dma_bufferset.o
-xilcam-objs := vdma.o
 cmabuffer-objs := cmabuf.o buffer.o
 
 # Call the Linux source makefiles to do the dirty work
-all: driver.c dma_bufferset.c dma_bufferset.h vdma.c buffer.c buffer.h
-	$(MAKE) ARCH=$(ARCH) -C $(KER_DIR) M=$(PWD) CROSS_COMPILE=aarch64-linux-gnu- modules
+all:
+	$(MAKE) -C $(KER_DIR) M=$(PWD) modules
 
 install:
-	scp -i ~/.ssh/zynq_linaro hwacc.ko ubuntu@10.42.0.196:
-	scp -i ~/.ssh/zynq_linaro xilcam.ko ubuntu@10.42.0.196:
-	scp -i ~/.ssh/zynq_linaro cmabuffer.ko ubuntu@10.42.0.196:
+	$(MAKE) -C $(KER_DIR) M=$(PWD) modules_install
+	sudo insmod cmabuffer
+	sudo insmod hwacc
 
 clean:
-	make ARCH=$(ARCH) -C $(KER_DIR) M=$(PWD) clean
+	make -C $(KER_DIR) M=$(PWD) clean
 
-cleanall:
-	make ARCH=$(ARCH) -C $(KER_DIR) M=$(PWD) clean
-	rm driver.c
-
-driver.c: driver.c.mako $(HWCONFIG)
-	python ../parameterize.py $(HWCONFIG) driver.c.mako:driver.c
-
-dma_bufferset.h: dma_bufferset.h.mako $(HWCONFIG)
-	python ../parameterize.py $(HWCONFIG) dma_bufferset.h.mako:dma_bufferset.h
-
-
+uninstall:
+	make -C $(KER_DIR) M=$(PWD) clean
+	sudo rmmod hwacc
+	sudo rmmod cmabuffer

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,5 +1,5 @@
 KER_DIR := /lib/modules/`uname -r`/build
-
+PWD := `pwd`
 # There are three modules created from this source code
 #   cmabuffer - Provides access to large contiguous memory buffers from Linux CMA
 #   hwacc - Driver for hardware accelerator, using one or more DMA engines
@@ -16,7 +16,7 @@ all:
 	$(MAKE) -C $(KER_DIR) M=$(PWD) modules
 
 install:
-	$(MAKE) -C $(KER_DIR) M=$(PWD) modules_install
+	$(MAKE) -C $(KER_DIR) M=$(PWD) modules
 	sudo insmod cmabuffer
 	sudo insmod hwacc
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,5 +1,7 @@
 KER_DIR := /lib/modules/`uname -r`/build
+
 PWD := `pwd`
+
 # There are three modules created from this source code
 #   cmabuffer - Provides access to large contiguous memory buffers from Linux CMA
 #   hwacc - Driver for hardware accelerator, using one or more DMA engines
@@ -16,14 +18,13 @@ all:
 	$(MAKE) -C $(KER_DIR) M=$(PWD) modules
 
 install:
-	$(MAKE) -C $(KER_DIR) M=$(PWD) modules
-	sudo insmod cmabuffer
-	sudo insmod hwacc
+	$(MAKE) -C $(KER_DIR) M=$(PWD) modules_install
+	sudo modprobe hwacc
+	sudo modprobe cmabuffer
 
 clean:
 	make -C $(KER_DIR) M=$(PWD) clean
 
 uninstall:
-	make -C $(KER_DIR) M=$(PWD) clean
 	sudo rmmod hwacc
 	sudo rmmod cmabuffer

--- a/drivers/cmabuf.c
+++ b/drivers/cmabuf.c
@@ -19,7 +19,7 @@ struct cdev *chardev;
 struct device *cmabuf_dev;
 struct class *cmabuf_class;
 
-const int debug_level = 4; // 0 is errors only, increasing numbers print more stuff
+const int debug_level = 1; // 0 is errors only, increasing numbers print more stuff
 
 // TODO: allow the file handle to be opened multiple times, and access
 // the same pool of memory?

--- a/drivers/dma_bufferset.c
+++ b/drivers/dma_bufferset.c
@@ -116,8 +116,6 @@ bool buffer_hasid(BufferList* list, int id)
     }
   }
   up(&(list->mutex));
-  if (found)
-    printk("buffer has id: %d\n", s->id);
   return found;
 }
 

--- a/drivers/dma_bufferset.c
+++ b/drivers/dma_bufferset.c
@@ -116,6 +116,8 @@ bool buffer_hasid(BufferList* list, int id)
     }
   }
   up(&(list->mutex));
+  if (found)
+    printk("buffer has id: %d\n", s->id);
   return found;
 }
 

--- a/drivers/driver.c
+++ b/drivers/driver.c
@@ -265,7 +265,6 @@ static int dev_close(struct inode *inode, struct file *file)
 static int setup_buffer_list(struct hwacc_drvdata *drvdata)
 {
         int i;
-        struct chan_buf *buf;
         BufferSet *buffer_pool = drvdata->buffer_pool;
 
         /* set up the image buffer set */
@@ -283,9 +282,10 @@ static int setup_buffer_list(struct hwacc_drvdata *drvdata)
                 buffer_pool[i].id = i;
                 buffer_pool[i].nr_channels = drvdata->nr_channels;
 
-                buffer_pool[i].chan_buf_list = devm_kzalloc(&drvdata->pdev->dev,
-                                                            sizeof (*buf),
-                                                            GFP_KERNEL);
+                buffer_pool[i].chan_buf_list = \
+                        devm_kzalloc(&drvdata->pdev->dev,
+                        sizeof (*buffer_pool[i].chan_buf_list),
+                        GFP_KERNEL);
 
                 DEBUG("enqueing buffer set %d\n", i);
                 buffer_enqueue(&drvdata->free_list, buffer_pool + i);

--- a/drivers/driver.c
+++ b/drivers/driver.c
@@ -200,7 +200,6 @@ static int dev_open(struct inode *inode, struct file *file)
         struct hwacc_drvdata *drvdata = container_of(inode->i_cdev,
                                                      struct hwacc_drvdata,
                                                      cdev);
-        struct chan_buf *buf;
 
         BufferSet *buffer_pool = drvdata->buffer_pool;
         file->private_data = drvdata;
@@ -209,10 +208,9 @@ static int dev_open(struct inode *inode, struct file *file)
         for (i = 0; i < N_DMA_BUFFERSETS; i++) {
                 for (j = 0; j < drvdata->nr_channels; j++) {
                         chan = drvdata->chan[j];
-                        buf = &buffer_pool[i].chan_buf_list[j];
-                        buf->sg = (unsigned long*)
+                        buffer_pool[i].chan_buf_list[j].sg = (unsigned long*) \
                                   __get_free_pages(GFP_KERNEL, SG_PAGEORDER);
-                        if (!buf->sg) {
+                        if (!buffer_pool[i].chan_buf_list[j].sg) {
                                 ERROR("failed to allocate memory for SG table"
                                       "chan %d\n", chan->id);
                                 return -ENOMEM;
@@ -284,7 +282,7 @@ static int setup_buffer_list(struct hwacc_drvdata *drvdata)
 
                 buffer_pool[i].chan_buf_list = \
                         devm_kzalloc(&drvdata->pdev->dev,
-                        sizeof (*buffer_pool[i].chan_buf_list),
+                        sizeof (struct chan_buf) * drvdata->nr_channels,
                         GFP_KERNEL);
 
                 DEBUG("enqueing buffer set %d\n", i);

--- a/dtconfig.py
+++ b/dtconfig.py
@@ -61,6 +61,7 @@ for hw_node in cfg['hw']:
 				overlay[node_name]['direction'] = 0
 				overlay[node_name]['hls-node'] = ""
 			else: # node_type == 'hls'
+                                # not using set because we want to perserve order
 				overlay[node_name]['dmas'] = []
 
 # filling in overlay info
@@ -74,12 +75,14 @@ for key in overlay:
                         overlay[node_name]['direction'] += 1
                         outputto = node["outputto"].split('.')[0]
                         overlay[node_name]['hls-node'] = outputto
-                        overlay[outputto]['dmas'].append(node_name)
+                        if node_name not in overlay[outputto]['dmas']:
+                            overlay[outputto]['dmas'].append(node_name)
 	else:
 		if node['outputto'] in overlay and overlay[node['outputto']]['definition']['type'] == 'dma':
-			overlay[node_name]['dmas'].append(node['outputto'])
-			overlay[node['outputto']]['hls-node'] = node_name
-			overlay[node['outputto']]['direction'] += 2
+                    if node['outputto'] not in overlay[node_name]['dmas']:
+                            overlay[node_name]['dmas'].append(node['outputto'])
+                            overlay[node['outputto']]['hls-node'] = node_name
+                            overlay[node['outputto']]['direction'] += 2
 
 
 # creating dt overlay

--- a/extractparams.py
+++ b/extractparams.py
@@ -1,6 +1,6 @@
 # Read the user parameters file (usually hwconfig.user) and extract
 # parameters for all of the user-defined modules specified there.
-
+from __future__ import print_function
 import os
 import yaml
 from lxml import etree
@@ -17,10 +17,10 @@ for module in params['hw']:
     continue
 
   if not os.path.isdir(module['path']):
-    print "[Error] Couldn't find IP for %s in %s!" % (module['name'], module['path'])
+    print("[Error] Couldn't find IP for %s in %s!" % (module['name'], module['path']))
     continue
 
-  print "Extracting parameters for " + module['name']
+  print("Extracting parameters for", module['name'])
   module['streams'] = [] # Start empty list of data streams
 
   desc = etree.parse(open(module['path']+'/component.xml'))
@@ -50,25 +50,38 @@ for module in params['hw']:
     if len(streamdepths) == 1:
       stream['depth'] = int(streamdepths[0])
     else:
-      print "[Warning] Failed to get stream depth for stream %s" % stream['name']
+      print("[Warning] Failed to get stream depth for stream", stream['name'])
 
     module['streams'].append(stream)
 
 # second pass
 for module in params["hw"]:
   if module["type"] == "hls":
+    input_types = ["dma", "csi"]
     # we need to collect all the DMA's that are pointing to it
     input_dmas = []
+    specified_dmas = []
     for dma in params["hw"]:
-      if dma["type"] != "dma" or dma["outputto"] != module["name"]:
+      if dma["type"] not in input_types:
         continue
       # we have found an input dma channel
-      input_dmas.append(dma)
+      if dma["outputto"] == module["name"]:
+        input_dmas.append(dma)
+      elif "." in dma["outputto"] and dma["outputto"].split(".")[0] == module["name"]:
+        specified_dmas.append(dma)
+      else:
+        print("[Warning] Mismatched channel name. Expect module name", module["name"],
+              "got", dma["outputto"])
     input_streams = [entry for entry in module["streams"]
                      if entry["type"] == "input"]
     # we need to make sure that the input list matches with the HLS IP
-    assert(len(input_dmas) == len(input_streams))
+    assert(len(input_dmas + specified_dmas) == len(input_streams))
+    # remove the input_streams that's been specified already
+    for dma in specified_dmas:
+      input_streams = [entry for entry in input_streams
+                       if entry["name"] != dma["outputto"].split(".")[-1]]
     # rename the outputto property
+    # also double check if the user already specifies the connections
     for i in range(len(input_dmas)):
       # updating the object by reference
       # the format will be hls_module.arg_#

--- a/hw/mkproject.tcl.mako
+++ b/hw/mkproject.tcl.mako
@@ -633,8 +633,8 @@ CONFIG.c_sg_include_stscntrl_strm {0} \
   <% stream['dwc'] = module['name'] + '_dwidth_' + stream['name'] %>
   set ${stream['dwc']} [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_dwidth_converter:1.1 ${stream['dwc']} ]
   set_property -dict [ list \
-      CONFIG.M_TDATA_NUM_BYTES {2} \
-      CONFIG.S_TDATA_NUM_BYTES {${stream['depth']}} \
+      CONFIG.S_TDATA_NUM_BYTES {2} \
+      CONFIG.M_TDATA_NUM_BYTES {${stream['depth']}} \
     ] $${stream['dwc']}
 
   connect_bd_intf_net -intf_net ${module['name']}_M_AXIS [get_bd_intf_pins ${module['name']}/${stream['name']}] [get_bd_intf_pins ${stream['dwc']}/S_AXIS]


### PR DESCRIPTION
- Multi-pass on `extractparams.py` to support automatic input channel match. In other words, there is no change in the `hwconfig.user` format.
   For instance:
`hwconfig.user`:
   ```yaml
   hw:
   - type: dma
     name: dma0
     outputto: dual
   - type: dma
     name: dma1
     outputto: dual
   - type: hls
     name: dual
     path: .
     outputto: dma0
   ```
   will be translated to `hwconfig.all` automatically
   ```yaml
   hw:
   - {name: dma0, out_connected: true, outputto: dual.arg_0, type: dma}
   - {name: dma1, out_connected: false, outputto: dual.arg_1, type: dma}
   - name: dual
     outputto: dma0
     path: .
     streams:
     - {depth: 1, name: arg_0, type: input}
     - {depth: 1, name: arg_1, type: input}
     - {depth: 1, name: arg_2, type: output}
     type: hls
     vlnv: xilinx.com:hls:hls_target:1.0
   name: dual
   ```
  `mkproject.tcl.mako` has also been modified to match the channel naming scheme.
- `hwacc` will arrange the dma channel in `[input, ..., input, output]` order based on the assumption that there is only one output channel. As a result, in user space programs should prepare the buffer accordingly. If in the future we need multiple output channels, a struct indicating how to rearrange dma channels can be passed to kernel via `ioctl` command.
- Because dma controller can be designed to have only one channel, there is no need in `dtoverlay.py` script to prescribe both `dma-in` and `dma-out`. This PR merged them into `dmas` and the `hwacc` driver is going to identify input or output channels.
- Fix a memory allocation bug that causes `free_page` error and potentially PC/SP alignment error.