### PR TITLE
Fixed bugs launching driver and waiting for buffers

### DIFF
--- a/drivers/dma_queue.c
+++ b/drivers/dma_queue.c
@@ -36,6 +36,22 @@ struct dma_queue_item_t *dma_queue_dequeue(struct dma_queue_t *queue)
 	return item;
 }
 
+struct dma_queue_item_t *dma_queue_peek(struct dma_queue_t *queue)
+{
+	struct dma_queue_item_t *item = NULL;
+	struct dma_queue_item_t *it;
+
+	while(down_interruptible(&queue->mutex) != 0);
+	list_for_each_entry(it, &queue->list, list) {
+		item = it;
+		break;
+	}
+
+	up(&queue->mutex);
+
+	return item;
+}
+
 /* get a queue item with given id */
 struct dma_queue_item_t *dma_queue_get(u32 id, struct dma_queue_t *queue)
 {

--- a/drivers/dma_queue.h
+++ b/drivers/dma_queue.h
@@ -24,6 +24,9 @@ void dma_queue_enqueue(struct dma_queue_item_t *item, struct dma_queue_t *queue)
 /* dequeue the first element in the queue */
 struct dma_queue_item_t *dma_queue_dequeue(struct dma_queue_t *queue);
 
+/* return the first element in the queue without removing it*/
+struct dma_queue_item_t *dma_queue_peek(struct dma_queue_t *queue);
+
 /* get a queue item with given id */
 struct dma_queue_item_t *dma_queue_get(u32 id, struct dma_queue_t *queue);
 


### PR DESCRIPTION
This PR fixes the two bugs I mentioned in my emails.
1. Fails to properly detect when the DMA engine is idle
2. Pops the buffer off the processing queue when it sends it to the DMA, meaning there's nothing to pick up when the DMA finishes.